### PR TITLE
blocks/gates rework

### DIFF
--- a/lexicons/app/bsky/embed/record.json
+++ b/lexicons/app/bsky/embed/record.json
@@ -81,7 +81,12 @@
       "properties": {
         "uri": { "type": "string", "format": "at-uri" },
         "blocked": { "type": "boolean", "const": true },
-        "author": { "type": "ref", "ref": "app.bsky.feed.defs#blockedAuthor" }
+        "author": { "type": "ref", "ref": "app.bsky.feed.defs#blockedAuthor" },
+
+        "social.zeppelin.value": {
+          "type": "unknown",
+          "description": "The record data itself."
+        }
       }
     },
     "viewDetached": {
@@ -89,7 +94,12 @@
       "required": ["uri", "detached"],
       "properties": {
         "uri": { "type": "string", "format": "at-uri" },
-        "detached": { "type": "boolean", "const": true }
+        "detached": { "type": "boolean", "const": true },
+
+        "social.zeppelin.value": {
+          "type": "unknown",
+          "description": "The record data itself."
+        }
       }
     }
   }

--- a/lexicons/app/bsky/unspecced/defs.json
+++ b/lexicons/app/bsky/unspecced/defs.json
@@ -131,9 +131,14 @@
     },
     "threadItemBlocked": {
       "type": "object",
-      "required": ["author"],
+      "required": ["author", "social.zeppelin.post"],
       "properties": {
-        "author": { "type": "ref", "ref": "app.bsky.feed.defs#blockedAuthor" }
+        "author": { "type": "ref", "ref": "app.bsky.feed.defs#blockedAuthor" },
+
+        "social.zeppelin.post": {
+          "type": "ref",
+          "ref": "app.bsky.feed.defs#postView"
+        }
       }
     },
     "ageAssuranceState": {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -10667,11 +10667,15 @@ export const schemaDict = {
       },
       threadItemBlocked: {
         type: 'object',
-        required: ['author'],
+        required: ['author', 'social.zeppelin.post'],
         properties: {
           author: {
             type: 'ref',
             ref: 'lex:app.bsky.feed.defs#blockedAuthor',
+          },
+          'social.zeppelin.post': {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.defs#postView',
           },
         },
       },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -5992,6 +5992,10 @@ export const schemaDict = {
             type: 'ref',
             ref: 'lex:app.bsky.feed.defs#blockedAuthor',
           },
+          'social.zeppelin.value': {
+            type: 'unknown',
+            description: 'The record data itself.',
+          },
         },
       },
       viewDetached: {
@@ -6005,6 +6009,10 @@ export const schemaDict = {
           detached: {
             type: 'boolean',
             const: true,
+          },
+          'social.zeppelin.value': {
+            type: 'unknown',
+            description: 'The record data itself.',
           },
         },
       },

--- a/packages/api/src/client/types/app/bsky/embed/record.ts
+++ b/packages/api/src/client/types/app/bsky/embed/record.ts
@@ -117,6 +117,8 @@ export interface ViewBlocked {
   uri: string
   blocked: true
   author: AppBskyFeedDefs.BlockedAuthor
+  /** The record data itself. */
+  'social.zeppelin.value'?: { [_ in string]: unknown }
 }
 
 const hashViewBlocked = 'viewBlocked'
@@ -133,6 +135,8 @@ export interface ViewDetached {
   $type?: 'app.bsky.embed.record#viewDetached'
   uri: string
   detached: true
+  /** The record data itself. */
+  'social.zeppelin.value'?: { [_ in string]: unknown }
 }
 
 const hashViewDetached = 'viewDetached'

--- a/packages/api/src/client/types/app/bsky/unspecced/defs.ts
+++ b/packages/api/src/client/types/app/bsky/unspecced/defs.ts
@@ -187,6 +187,7 @@ export function validateThreadItemNotFound<V>(v: V) {
 export interface ThreadItemBlocked {
   $type?: 'app.bsky.unspecced.defs#threadItemBlocked'
   author: AppBskyFeedDefs.BlockedAuthor
+  'social.zeppelin.post': AppBskyFeedDefs.PostView
 }
 
 const hashThreadItemBlocked = 'threadItemBlocked'

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -10667,11 +10667,15 @@ export const schemaDict = {
       },
       threadItemBlocked: {
         type: 'object',
-        required: ['author'],
+        required: ['author', 'social.zeppelin.post'],
         properties: {
           author: {
             type: 'ref',
             ref: 'lex:app.bsky.feed.defs#blockedAuthor',
+          },
+          'social.zeppelin.post': {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.defs#postView',
           },
         },
       },

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -5992,6 +5992,10 @@ export const schemaDict = {
             type: 'ref',
             ref: 'lex:app.bsky.feed.defs#blockedAuthor',
           },
+          'social.zeppelin.value': {
+            type: 'unknown',
+            description: 'The record data itself.',
+          },
         },
       },
       viewDetached: {
@@ -6005,6 +6009,10 @@ export const schemaDict = {
           detached: {
             type: 'boolean',
             const: true,
+          },
+          'social.zeppelin.value': {
+            type: 'unknown',
+            description: 'The record data itself.',
           },
         },
       },

--- a/packages/bsky/src/lexicon/types/app/bsky/embed/record.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/embed/record.ts
@@ -117,6 +117,8 @@ export interface ViewBlocked {
   uri: string
   blocked: true
   author: AppBskyFeedDefs.BlockedAuthor
+  /** The record data itself. */
+  'social.zeppelin.value'?: { [_ in string]: unknown }
 }
 
 const hashViewBlocked = 'viewBlocked'
@@ -133,6 +135,8 @@ export interface ViewDetached {
   $type?: 'app.bsky.embed.record#viewDetached'
   uri: string
   detached: true
+  /** The record data itself. */
+  'social.zeppelin.value'?: { [_ in string]: unknown }
 }
 
 const hashViewDetached = 'viewDetached'

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/defs.ts
@@ -187,6 +187,7 @@ export function validateThreadItemNotFound<V>(v: V) {
 export interface ThreadItemBlocked {
   $type?: 'app.bsky.unspecced.defs#threadItemBlocked'
   author: AppBskyFeedDefs.BlockedAuthor
+  'social.zeppelin.post': AppBskyFeedDefs.PostView
 }
 
 const hashThreadItemBlocked = 'threadItemBlocked'

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -1266,52 +1266,40 @@ export class Views {
       : isOPPost
 
     const anchorDepth = 0 // The depth of the anchor post is always 0.
-    let anchorTree: ThreadTree
     let hasOtherReplies = false
 
-    if (this.noUnauthenticatedPost(state, postView)) {
-      anchorTree = {
-        type: 'noUnauthenticated',
-        item: this.threadV2ItemNoUnauthenticated({
-          uri: anchorUri,
-          depth: anchorDepth,
-        }),
-        parent,
-      }
-    } else {
-      const { replies, hasOtherReplies: hasOtherRepliesShadow } =
-        !anchorViolatesThreadGate
-          ? this.threadV2Replies(
-              {
-                parentUri: anchorUri,
-                isOPThread,
-                opDid,
-                rootUri,
-                childrenByParentUri,
-                below,
-                depth: 1,
-                branchingFactor,
-                prioritizeFollowedUsers,
-              },
-              state,
-            )
-          : { replies: undefined, hasOtherReplies: false }
-      hasOtherReplies = hasOtherRepliesShadow
+    const { replies, hasOtherReplies: hasOtherRepliesShadow } =
+      !anchorViolatesThreadGate
+        ? this.threadV2Replies(
+            {
+              parentUri: anchorUri,
+              isOPThread,
+              opDid,
+              rootUri,
+              childrenByParentUri,
+              below,
+              depth: 1,
+              branchingFactor,
+              prioritizeFollowedUsers,
+            },
+            state,
+          )
+        : { replies: undefined, hasOtherReplies: false }
+    hasOtherReplies = hasOtherRepliesShadow
 
-      anchorTree = {
-        type: 'post',
-        item: this.threadV2ItemPost({
-          depth: anchorDepth,
-          isOPThread,
-          postView,
-          repliesAllowance: Infinity, // While we don't have pagination.
-          uri: anchorUri,
-        }),
-        tags: post.tags,
-        hasOPLike: !!state.threadContexts?.get(postView.uri)?.like,
-        parent,
-        replies,
-      }
+    const anchorTree: ThreadTree = {
+      type: 'post',
+      item: this.threadV2ItemPost({
+        depth: anchorDepth,
+        isOPThread,
+        postView,
+        repliesAllowance: Infinity, // While we don't have pagination.
+        uri: anchorUri,
+      }),
+      tags: post.tags,
+      hasOPLike: !!state.threadContexts?.get(postView.uri)?.like,
+      parent,
+      replies,
     }
 
     const thread = sortTrimFlattenThreadTree(anchorTree, {
@@ -1409,20 +1397,6 @@ export class Views {
     const isOPThread = parent
       ? isOPThreadFromRootToParent && isOPPost
       : isOPPost
-
-    if (this.noUnauthenticatedPost(state, postView)) {
-      return {
-        tree: {
-          type: 'noUnauthenticated',
-          item: this.threadV2ItemNoUnauthenticated({
-            uri,
-            depth,
-          }),
-          parent,
-        },
-        isOPThread,
-      }
-    }
 
     const parentUri = post.record.reply?.parent.uri
     const hasMoreParents = !!parentUri && !parent
@@ -1861,11 +1835,6 @@ export class Views {
       return null
     }
     if (!this.viewerSeesNeedsReview({ uri, did: authorDid }, state)) {
-      return null
-    }
-
-    // No unauthenticated.
-    if (this.noUnauthenticatedPost(state, postView)) {
       return null
     }
 

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -1225,6 +1225,7 @@ export class Views {
             uri: anchorUri,
             depth: 0,
             authorDid: postView.author.did,
+            postView,
             state,
           }),
         ],
@@ -1371,12 +1372,10 @@ export class Views {
       return undefined
     }
 
-    // Blocked (1p and 3p for parent).
+    // Blocked (1p [no 3p] for parent).
     const authorDid = postView.author.did
     const has1pBlock = this.viewerBlockExists(authorDid, state)
-    const has3pBlock =
-      !state.ctx?.include3pBlocks && state.postBlocks?.get(childUri)?.parent
-    if (has1pBlock || has3pBlock) {
+    if (has1pBlock) {
       return {
         tree: {
           type: 'blocked',
@@ -1384,6 +1383,7 @@ export class Views {
             uri,
             depth,
             authorDid,
+            postView,
             state,
           }),
         },
@@ -1633,8 +1633,8 @@ export class Views {
         author: {
           did: authorDid,
           viewer: this.blockedProfileViewer(authorDid, state),
-          'social.zeppelin.labels': postView.author.labels ?? [],
         },
+        'social.zeppelin.post': postView,
       },
     }
   }
@@ -1855,11 +1855,9 @@ export class Views {
       return null
     }
 
-    // Blocked (1p and 3p for replies).
+    // Blocked (1p [no 3p] for replies).
     const has1pBlock = this.viewerBlockExists(authorDid, state)
-    const has3pBlock =
-      !state.ctx?.include3pBlocks && state.postBlocks?.get(uri)?.parent
-    if (has1pBlock || has3pBlock) {
+    if (has1pBlock) {
       return null
     }
     if (!this.viewerSeesNeedsReview({ uri, did: authorDid }, state)) {

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -1616,11 +1616,13 @@ export class Views {
     uri,
     depth,
     authorDid,
+    postView,
     state,
   }: {
     uri: string
     depth: number
     authorDid: string
+    postView: PostView
     state: HydrationState
   }): ThreadItemValueBlocked {
     return {
@@ -1631,6 +1633,7 @@ export class Views {
         author: {
           did: authorDid,
           viewer: this.blockedProfileViewer(authorDid, state),
+          'social.zeppelin.labels': postView.author.labels ?? [],
         },
       },
     }

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -1990,16 +1990,22 @@ export class Views {
     }
   }
 
-  embedDetached(uri: string): {
+  embedDetached(
+    uri: string,
+    state: HydrationState,
+    depth: number,
+  ): {
     $type: 'app.bsky.embed.record#view'
     record: $Typed<EmbedDetached>
   } {
+    const postView = this.post(uri, state, depth)
     return {
       $type: 'app.bsky.embed.record#view',
       record: {
         $type: 'app.bsky.embed.record#viewDetached',
         uri,
         detached: true,
+        'social.zeppelin.value': postView,
       },
     }
   }
@@ -2007,11 +2013,13 @@ export class Views {
   embedBlocked(
     uri: string,
     state: HydrationState,
+    depth: number,
   ): {
     $type: 'app.bsky.embed.record#view'
     record: $Typed<EmbedBlocked>
   } {
     const creator = creatorFromUri(uri)
+    const postView = this.post(uri, state, depth)
     return {
       $type: 'app.bsky.embed.record#view',
       record: {
@@ -2022,6 +2030,7 @@ export class Views {
           did: creator,
           viewer: this.blockedProfileViewer(creator, state),
         },
+        'social.zeppelin.value': postView,
       },
     }
   }
@@ -2076,7 +2085,7 @@ export class Views {
       this.viewerBlockExists(parsedUri.hostname, state) ||
       (!state.ctx?.include3pBlocks && state.postBlocks?.get(postUri)?.embed)
     ) {
-      return this.embedBlocked(uri, state)
+      return this.embedBlocked(uri, state, depth)
     }
 
     if (parsedUri.collection === ids.AppBskyFeedPost) {

--- a/packages/lex-cli/src/codegen/lex-gen.ts
+++ b/packages/lex-cli/src/codegen/lex-gen.ts
@@ -211,7 +211,7 @@ function genObject(
           types.push('{ $type: string }')
         }
         iface.addProperty({
-          name: `${propKey}${req ? '' : '?'}`,
+          name: `"${propKey}"${req ? '' : '?'}`,
           type: makeType(types, { nullable: propNullable }),
         })
         continue
@@ -221,7 +221,7 @@ function genObject(
           let propAst
           if (propDef.items.type === 'ref') {
             propAst = iface.addProperty({
-              name: `${propKey}${req ? '' : '?'}`,
+              name: `"${propKey}"${req ? '' : '?'}`,
               type: makeType(
                 refToType(
                   propDef.items.ref,
@@ -242,7 +242,7 @@ function genObject(
               types.push('{ $type: string }')
             }
             propAst = iface.addProperty({
-              name: `${propKey}${req ? '' : '?'}`,
+              name: `"${propKey}"${req ? '' : '?'}`,
               type: makeType(types, {
                 nullable: propNullable,
                 array: true,
@@ -250,7 +250,7 @@ function genObject(
             })
           } else {
             propAst = iface.addProperty({
-              name: `${propKey}${req ? '' : '?'}`,
+              name: `"${propKey}"${req ? '' : '?'}`,
               type: makeType(primitiveOrBlobToType(propDef.items), {
                 nullable: propNullable,
                 array: true,
@@ -262,7 +262,7 @@ function genObject(
           //= propName: type
           genComment(
             iface.addProperty({
-              name: `${propKey}${req ? '' : '?'}`,
+              name: `"${propKey}"${req ? '' : '?'}`,
               type: makeType(primitiveOrBlobToType(propDef), {
                 nullable: propNullable,
               }),


### PR DESCRIPTION
(redoing because I accidentally force pushed)

- getAuthorFeed returns posts regardless of block
- ignore third party blocks in thread v2 response
- ignore no-unauthenticated in thread v2 response
- include postView in blocked thread item
- include post record in blocked & detached quote embed
- replies violating threadgate will display under "other", like hidden & muted replies
- parents/anchor post violating threadgate will display without indication